### PR TITLE
Centers .card class in mobile version

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -43,6 +43,8 @@ p {
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
+  margin-left: auto;
+  margin-right: auto;
 }
 
 .imagen {


### PR DESCRIPTION

![Screenshot from 2024-08-22 20-52-33](https://github.com/user-attachments/assets/debcacc1-049d-486f-8c7e-1ba770564b45)
Adds left and right auto margins to css so the div is centered in the mobile version. Tested locally on Firefox 129.0.2.